### PR TITLE
Fix for alpha of base texture taking precedence over alpha of overlay texture

### DIFF
--- a/RT/Renderer/Backend/DX12/assets/shaders/include/common.hlsl
+++ b/RT/Renderer/Backend/DX12/assets/shaders/include/common.hlsl
@@ -802,7 +802,7 @@ bool IsHitTransparent(uint instance_idx, uint primitive_idx, float2 barycentrics
 			return true;
 		}
 
-		if ( dither >= albedo2.a )
+		if ( dither < albedo2.a )
 		{
 			material = g_materials[material_index2];
 			return dither >= base_alpha;


### PR DESCRIPTION
Fix for issue where the alpha channel of a base texture would take precedence over alpha channel of overlay texture.

![scrn0126](https://github.com/user-attachments/assets/92df7a22-a873-418d-8430-197f1a7ac0ec)
![scrn0127](https://github.com/user-attachments/assets/21530cf8-e3a2-4fb3-a79e-73a0fbc2c18b)
