### PR TITLE
Implement a visibility table for handling overlapping segments rendering errors to replace retrace rays test.

### DIFF
--- a/RT/Game/level.c
+++ b/RT/Game/level.c
@@ -8,6 +8,7 @@
 #include "wall.h"
 #include "automap.h"
 #include "render.h"
+#include "fvi.h"
 
 // ------------------------------------------------------------------
 // RT includes
@@ -25,6 +26,7 @@
 // Current active level
 RT_ResourceHandle g_level_resource = { 0 };
 RT_ResourceHandle g_level_with_portals_resource = { 0 };
+RT_ResourceHandle g_level_visibility_table = { 0 };
 int g_active_level = 0;
 
 int m_light_count = 0;
@@ -140,6 +142,9 @@ bool RT_UploadLevelGeometry(RT_ResourceHandle* level_handle, RT_ResourceHandle* 
 		RT_Triangle* triangles = RT_ArenaAllocArray(&g_thread_arena, Num_segments * 6 * 2, RT_Triangle);
 		RT_Triangle* portal_triangles = RT_ArenaAllocArray(&g_thread_arena, Num_segments * 6 * 2, RT_Triangle);
 
+		uint32_t visibility_table_stride = (Num_segments + 31) / 32;  // make table stride match 32bit gpu data type
+		uint32_t* visibility_table = RT_ArenaAllocArray(&g_thread_arena, visibility_table_stride * Num_segments, uint32_t);
+
 		// Init lights segment id list
 		for (size_t i = 0; i < _countof(m_lights_seg_ids); ++i) {
 			m_lights_seg_ids[i] = -1;
@@ -151,9 +156,99 @@ bool RT_UploadLevelGeometry(RT_ResourceHandle* level_handle, RT_ResourceHandle* 
 		int num_portal_triangles = 0;
 
 		int num_mesh = 0;
+
+		//int visibility_row_size = (Num_segments + 8 - 1) / 8;
+		//char* visibility_table = RT_ArenaAllocArray(&g_thread_arena, visibility_row_size * Num_segments, char);
+
 		for (int seg_id = 0; seg_id < Num_segments; seg_id++)
 		{
 			segment *seg = &Segments[seg_id];
+
+			// compute segment visibility table
+
+			vms_vector seg_center;
+			vm_vec_zero(&seg_center);
+
+			vms_vector start_point;
+			vms_vector end_point;
+
+			compute_segment_center(&seg_center, seg);
+
+			for (int vertex_index = 0; vertex_index <= MAX_VERTICES_PER_SEGMENT; vertex_index++)
+			{
+				vm_vec_zero(&start_point);
+				vm_vec_zero(&end_point);
+
+				if (vertex_index == MAX_VERTICES_PER_SEGMENT)
+				{
+					// do the center point
+					start_point = seg_center;
+				}
+				else
+				{
+					// do one of the vertices slighly offset towards the center
+					vms_vector p1 = Vertices[seg->verts[vertex_index]];
+					vm_vec_scale(&p1, fl2f(0.99f));
+
+					vms_vector p2 = seg_center;
+					vm_vec_scale(&p2, fl2f(0.01f));
+
+					vm_vec_add(&start_point, &p1, &p2);
+				}
+
+				// now shoot a whole bunch of rays from this point and see where they go
+				for (int ray_index = 0; ray_index < 1000; ray_index++)
+				{
+					vms_vector direction;
+					make_random_vector(&direction);
+
+					vm_vec_scale(&direction, fl2f(10000.f));
+
+					vm_vec_add(&end_point, &start_point, &direction);
+
+					int fate;
+					fvi_info hit_info;
+					fvi_query fq;
+
+					fq.p0 = &start_point;
+					fq.startseg = seg_id;
+					fq.p1 = &end_point;
+					fq.rad = 0;
+					fq.thisobjnum = -1;
+					fq.ignore_obj_list = NULL;
+					fq.flags = FQ_TRANSWALL | FQ_GET_SEGLIST;
+
+					fate = find_vector_intersection(&fq, &hit_info);
+
+					/*printf("%d / %d\n", seg_id, Num_segments);
+
+					
+					for (int seg_index = 0; seg_index < hit_info.n_segs; seg_index++)
+					{
+						//sprintf(animation_frame_name, "%s%d", animation_root_name, frame_num);
+						//sprintf(animation_frame_name, "%s%d", animation_root_name, frame_num);
+						printf("%d,", hit_info.seglist[seg_index]);
+					}
+
+					printf("%d,", hit_info.hit_seg);
+
+					printf("\n");*/
+
+					if (fate == HIT_WALL)
+					{
+						//int hit_seghit_info.hit_seg
+						size_t wordIndex = hit_info.hit_seg / 32;
+						size_t bitIndex = hit_info.hit_seg % 32;
+						size_t table_index = ((size_t)seg_id) * ((size_t)visibility_table_stride) + wordIndex;
+
+						visibility_table[table_index] |= (1u << bitIndex);
+
+					}
+					
+
+
+				}
+			}
 
 			for (int side_index = 0; side_index < MAX_SIDES_PER_SEGMENT; side_index++)
 			{
@@ -344,6 +439,24 @@ bool RT_UploadLevelGeometry(RT_ResourceHandle* level_handle, RT_ResourceHandle* 
 		*portals_handle = RT_UploadMesh(&params_portals);
 		RT_LOGF(RT_LOGSERVERITY_INFO, "UPLOADING MESH OK\n");
 
+		// temp output for debugging
+		printf("vis table:\n");
+		for (uint vis_table_index = 0; vis_table_index < visibility_table_stride * Num_segments; vis_table_index++)
+		{
+			printf("%d", visibility_table[vis_table_index]);
+		}
+
+		RT_UploadVisibilityTableParams params_visibility_table =
+		{
+			.visibility_table_segment_count = Num_segments,
+			.visibility_table_element_count = visibility_table_stride * Num_segments,
+			.visibility_table = visibility_table
+		};
+
+		RT_LOGF(RT_LOGSERVERITY_INFO, "UPLOADING VISIBILITY TABLE >>\n");
+		RT_UploadVisibilityTable(&params_visibility_table);
+		RT_LOGF(RT_LOGSERVERITY_INFO, "UPLOADING VISIBILITY TABLE\n");
+
 		// load and unload materials based on if they are needed for this level.
 		RT_SyncMaterialStates();
 	}
@@ -373,6 +486,15 @@ bool RT_UnloadLevel()
 
 		return true;
 	}
+
+	// unload the visibility table
+	/*if (RT_RESOURCE_HANDLE_VALID(g_level_visibility_table))
+	{
+		??RT_ReleaseMesh(g_level_with_portals_resource); its not a mesh so what do I do here?
+		g_level_visibility_table = RT_RESOURCE_HANDLE_NULL;
+
+		return true;
+	}*/
 
 	return false;
 }

--- a/RT/Game/level.c
+++ b/RT/Game/level.c
@@ -23,6 +23,9 @@
 
 // ------------------------------------------------------------------
 
+#define MAX_VISIBILITY_TABLE_SEARCH_SEGMENTS 9000
+#define MAX_VISIBILITY_TABLE_SEARCH_RAYS 100
+
 // Current active level
 RT_ResourceHandle g_level_resource = { 0 };
 RT_ResourceHandle g_level_with_portals_resource = { 0 };
@@ -125,6 +128,101 @@ void RT_ExtractLightsFromSide(side* side, RT_Vertex* vertices, RT_Vec3 normal, i
 	}
 }
 
+void UpdateVisibilityTable(uint32_t* visibility_table, uint32_t visibility_table_stride, int seg_from, int seg_to)
+{
+	size_t wordIndex = seg_to / 32;
+	size_t bitIndex = seg_to % 32;
+	size_t table_index = ((size_t)seg_from) * ((size_t)visibility_table_stride) + wordIndex;
+
+	visibility_table[table_index] |= (1u << bitIndex);
+}
+
+void pick_random_point_on_side(vms_vector* random_point, const side* s, const int* vertnum_list)
+{
+	// get vertex information
+	vms_vector quad_vertices[4];
+	vms_vector tri_vertices[3];
+
+	for (int vertex_index = 0; vertex_index < 4; vertex_index++)
+	{
+		const int vertex_id = vertnum_list[vertex_index];
+		quad_vertices[vertex_index] = Vertices[vertex_id];
+	}
+
+	// should we pick a point on the first or second triangle of the quad?
+	// picking one randomly should be good enough for most casses, but in the event of a very skewed segment where one triangle is much larger than the other... the results would be skewed
+	// if it becomes a problem look at using triangle size to weight the probability.
+
+	bool first_tri = d_rand() > 16384;
+
+	switch (s->type)
+	{
+	case SIDE_IS_TRI_13:
+
+		if (first_tri)
+		{
+			tri_vertices[0] = quad_vertices[0];
+			tri_vertices[1] = quad_vertices[1];
+			tri_vertices[2] = quad_vertices[3];
+		}
+		else
+		{
+			tri_vertices[0] = quad_vertices[1];
+			tri_vertices[1] = quad_vertices[2];
+			tri_vertices[2] = quad_vertices[3];
+		}
+		break;
+
+	case SIDE_IS_QUAD:
+	case SIDE_IS_TRI_02:
+	default:
+
+		if (first_tri)
+		{
+			tri_vertices[0] = quad_vertices[0];
+			tri_vertices[1] = quad_vertices[1];
+			tri_vertices[2] = quad_vertices[2];
+		}
+		else
+		{
+			tri_vertices[0] = quad_vertices[0];
+			tri_vertices[1] = quad_vertices[2];
+			tri_vertices[2] = quad_vertices[3];
+		}
+		break;
+
+	}
+
+	int u = d_rand() * 2;	// d_rand only returns 0.0 to 0.5, so double it
+	int v = d_rand() * 2;
+
+	// if u + v > 1.0 flip them
+	if (u + v > D_RAND_MAX * 2)
+	{
+		u = (D_RAND_MAX * 2) - u;
+		v = (D_RAND_MAX * 2) - v;
+	}
+
+	// create vectors for the two sides connected to vertex 0
+	vms_vector side1, side2;
+	vm_vec_sub(&side1, &tri_vertices[1], &tri_vertices[0]);
+	vm_vec_sub(&side2, &tri_vertices[2], &tri_vertices[0]);
+
+	// scale them by u,v
+	vm_vec_scale(&side1, u);
+	vm_vec_scale(&side2, v);
+
+	// add the two scaled sides together
+	vms_vector offset_vector;
+	vm_vec_add(&offset_vector, &side1, &side2);
+
+	// add offset to vertex 0, we should now have a random point on the side
+	vm_vec_add(random_point, &tri_vertices[0], &offset_vector);
+
+	return;
+	
+}
+
 bool RT_UploadLevelGeometry(RT_ResourceHandle* level_handle, RT_ResourceHandle* portals_handle)
 {
 
@@ -157,98 +255,14 @@ bool RT_UploadLevelGeometry(RT_ResourceHandle* level_handle, RT_ResourceHandle* 
 
 		int num_mesh = 0;
 
-		//int visibility_row_size = (Num_segments + 8 - 1) / 8;
-		//char* visibility_table = RT_ArenaAllocArray(&g_thread_arena, visibility_row_size * Num_segments, char);
+		uint highest_ray_test = 0;
 
 		for (int seg_id = 0; seg_id < Num_segments; seg_id++)
 		{
 			segment *seg = &Segments[seg_id];
 
-			// compute segment visibility table
-
-			vms_vector seg_center;
-			vm_vec_zero(&seg_center);
-
-			vms_vector start_point;
-			vms_vector end_point;
-
-			compute_segment_center(&seg_center, seg);
-
-			for (int vertex_index = 0; vertex_index <= MAX_VERTICES_PER_SEGMENT; vertex_index++)
-			{
-				vm_vec_zero(&start_point);
-				vm_vec_zero(&end_point);
-
-				if (vertex_index == MAX_VERTICES_PER_SEGMENT)
-				{
-					// do the center point
-					start_point = seg_center;
-				}
-				else
-				{
-					// do one of the vertices slighly offset towards the center
-					vms_vector p1 = Vertices[seg->verts[vertex_index]];
-					vm_vec_scale(&p1, fl2f(0.99f));
-
-					vms_vector p2 = seg_center;
-					vm_vec_scale(&p2, fl2f(0.01f));
-
-					vm_vec_add(&start_point, &p1, &p2);
-				}
-
-				// now shoot a whole bunch of rays from this point and see where they go
-				for (int ray_index = 0; ray_index < 1000; ray_index++)
-				{
-					vms_vector direction;
-					make_random_vector(&direction);
-
-					vm_vec_scale(&direction, fl2f(10000.f));
-
-					vm_vec_add(&end_point, &start_point, &direction);
-
-					int fate;
-					fvi_info hit_info;
-					fvi_query fq;
-
-					fq.p0 = &start_point;
-					fq.startseg = seg_id;
-					fq.p1 = &end_point;
-					fq.rad = 0;
-					fq.thisobjnum = -1;
-					fq.ignore_obj_list = NULL;
-					fq.flags = FQ_TRANSWALL | FQ_GET_SEGLIST;
-
-					fate = find_vector_intersection(&fq, &hit_info);
-
-					/*printf("%d / %d\n", seg_id, Num_segments);
-
-					
-					for (int seg_index = 0; seg_index < hit_info.n_segs; seg_index++)
-					{
-						//sprintf(animation_frame_name, "%s%d", animation_root_name, frame_num);
-						//sprintf(animation_frame_name, "%s%d", animation_root_name, frame_num);
-						printf("%d,", hit_info.seglist[seg_index]);
-					}
-
-					printf("%d,", hit_info.hit_seg);
-
-					printf("\n");*/
-
-					if (fate == HIT_WALL)
-					{
-						//int hit_seghit_info.hit_seg
-						size_t wordIndex = hit_info.hit_seg / 32;
-						size_t bitIndex = hit_info.hit_seg % 32;
-						size_t table_index = ((size_t)seg_id) * ((size_t)visibility_table_stride) + wordIndex;
-
-						visibility_table[table_index] |= (1u << bitIndex);
-
-					}
-					
-
-
-				}
-			}
+			// add self to visibility table row
+			UpdateVisibilityTable(visibility_table, visibility_table_stride, seg_id, seg_id);
 
 			for (int side_index = 0; side_index < MAX_SIDES_PER_SEGMENT; side_index++)
 			{
@@ -260,6 +274,119 @@ bool RT_UploadLevelGeometry(RT_ResourceHandle* level_handle, RT_ResourceHandle* 
 				get_side_verts(&vertnum_list, seg_id, side_index);
 
 				int vert_ids[4];
+
+				// compute visibility table for this side
+
+				bool visited[MAX_SEGMENTS] = { false };
+				int search_stack[MAX_VISIBILITY_TABLE_SEARCH_SEGMENTS];
+				for (int i = 0; i < MAX_VISIBILITY_TABLE_SEARCH_SEGMENTS; i++)
+				{
+					search_stack[i] = -1;
+				}
+				int search_stack_size = 0;
+
+				// if side has a connected segment add that to the search pool as search starter.  if there isn't one there will be no search for this side
+				if (seg->children[side_index] > -1)
+				{
+					// this is a portal surface of some kind
+
+					// direct children can always be seen. add it to visibility table
+					UpdateVisibilityTable(visibility_table, visibility_table_stride, seg_id, seg->children[side_index]);
+					UpdateVisibilityTable(visibility_table, visibility_table_stride, seg->children[side_index], seg_id);
+
+					// add this child to the search stack
+					search_stack_size++;
+					search_stack[search_stack_size - 1] = seg->children[side_index];
+				}
+
+				while (search_stack_size > 0)
+				{
+					// pop the last segment from search stack
+					int search_segment_index = search_stack[search_stack_size - 1];
+					search_stack[search_stack_size - 1] = -1;
+					search_stack_size--;
+
+					// if we've visited this segment before, no need to do it again
+					if (!visited[search_segment_index])
+					{
+						segment* search_seg = &Segments[search_segment_index];
+
+						// mark as visited
+						visited[search_segment_index] = true;
+
+						// iterate over the sides of the search segment to see if they are portals that lead to other segments
+
+						for (int search_side_index = 0; search_side_index < MAX_SIDES_PER_SEGMENT; search_side_index++)
+						{
+							if (search_seg->children[search_side_index] > -1)
+							{
+								// this side is a portal to another segment, search it
+								side* search_s = &search_seg->sides[search_side_index];
+
+								// check if this portal can be seen by the portal surface that started this search
+
+								// pick a bunch of random points on the original segment portal surface and a bunch of points on the current portal surface and trace a line between.
+								// if any of those lines are not blocked by anything, they can see each other
+								// which means that the search_segment can see into this child segment
+								// add it to the visibility table
+
+								bool can_see = false;
+								for (uint ray_index = 0; ray_index < MAX_VISIBILITY_TABLE_SEARCH_RAYS && !can_see; ray_index++)
+								{
+									vms_vector start_point, end_point;
+
+									pick_random_point_on_side(&start_point, s, vertnum_list);
+
+									int search_s_vertnum_list[4];
+									get_side_verts(&search_s_vertnum_list, search_segment_index, search_side_index);
+									pick_random_point_on_side(&end_point, search_s, search_s_vertnum_list);
+
+									int fate;
+									fvi_info hit_info;
+									fvi_query fq;
+
+									fq.startseg = seg_id;
+									fq.p0 = &start_point;
+									fq.p1 = &end_point;
+									fq.rad = 0;
+									fq.thisobjnum = -1;
+									fq.ignore_obj_list = NULL;
+									fq.flags = FQ_ALL_CHILDREN;
+
+									fate = find_vector_intersection(&fq, &hit_info);
+
+									if (fate == HIT_NONE)
+									{
+										// clean line of sight.  update visibility table and end search for this side
+										can_see = true;
+
+										UpdateVisibilityTable(visibility_table, visibility_table_stride, seg_id, search_seg->children[search_side_index]);
+										UpdateVisibilityTable(visibility_table, visibility_table_stride, search_seg->children[search_side_index], seg_id);
+
+										// add this child to the search stack
+
+										if(search_stack_size < MAX_VISIBILITY_TABLE_SEARCH_SEGMENTS)
+										{ 
+											search_stack_size++;
+											search_stack[search_stack_size - 1] = search_seg->children[search_side_index];
+										}
+
+										if (ray_index > highest_ray_test)
+										{
+											highest_ray_test = ray_index;
+										}
+
+									}
+								}
+							}
+						}
+					}
+
+				}
+					
+				// end visibility table calculation
+
+				// begin geometry extraction
 
 				for (int v = 0; v < 4; v++)
 				{

--- a/RT/Renderer/Backend/Common/include/Renderer.h
+++ b/RT/Renderer/Backend/Common/include/Renderer.h
@@ -228,6 +228,15 @@ typedef struct RT_UploadMeshParams
 	const char* name; // Optional, used for enhanced graphics debugging
 } RT_UploadMeshParams;
 
+typedef struct RT_UploadVisibilityTableParams
+{
+	uint32_t visibility_table_segment_count;
+	uint32_t visibility_table_element_count;
+	uint32_t* visibility_table;
+
+	//const char* name; // Optional, used for enhanced graphics debugging
+} RT_UploadVisibilityTableParams;
+
 typedef struct RT_DoRendererDebugMenuParams
 {
 	bool ui_has_cursor_focus;
@@ -330,6 +339,7 @@ RT_API RT_ResourceHandle RT_UploadTexture(const RT_UploadTextureParams* params);
 // Returns the material_index you passed in, or UINT16_MAX if it was out of bounds.
 RT_API uint16_t RT_UpdateMaterial(uint16_t material_index, const RT_Material *material);
 RT_API RT_ResourceHandle RT_UploadMesh(const RT_UploadMeshParams* params);
+RT_API void RT_UploadVisibilityTable(const RT_UploadVisibilityTableParams* params);
 RT_API void RT_ReleaseTexture(const RT_ResourceHandle texture_handle);
 RT_API void RT_ReleaseMesh(const RT_ResourceHandle mesh_handle);
 RT_API bool RT_GenerateTangents(RT_Triangle *triangles, size_t triangle_count); // Will modify triangles in-place to add tangent vectors

--- a/RT/Renderer/Backend/DX12/assets/shaders/include/common.hlsl
+++ b/RT/Renderer/Backend/DX12/assets/shaders/include/common.hlsl
@@ -175,8 +175,8 @@ StructuredBuffer<Material>      g_materials                        : register(t2
 StructuredBuffer<InstanceData>  g_instance_data_buffer             : register(t3);
 ByteAddressBuffer               g_material_edges                   : register(t4);
 ByteAddressBuffer               g_material_indices                 : register(t5);
-Texture2D                       g_blue_noise[BLUE_NOISE_TEX_COUNT] : register(t6);
-StructuredBuffer<uint>          g_visibility_table_buffer		   : register(t23);  // guessing its 23
+StructuredBuffer<uint>          g_visibility_table_buffer		   : register(t6);
+Texture2D                       g_blue_noise[BLUE_NOISE_TEX_COUNT] : register(t7);
 Texture2D						g_bindless_srvs[]				   : register(t0, space3);
 StructuredBuffer<RT_Triangle>	g_bindless_triangle_buffers[]	   : register(t0, space4);
 

--- a/RT/Renderer/Backend/DX12/assets/shaders/include/common.hlsl
+++ b/RT/Renderer/Backend/DX12/assets/shaders/include/common.hlsl
@@ -176,6 +176,7 @@ StructuredBuffer<InstanceData>  g_instance_data_buffer             : register(t3
 ByteAddressBuffer               g_material_edges                   : register(t4);
 ByteAddressBuffer               g_material_indices                 : register(t5);
 Texture2D                       g_blue_noise[BLUE_NOISE_TEX_COUNT] : register(t6);
+StructuredBuffer<uint>          g_visibility_table_buffer		   : register(t23);  // guessing its 23
 Texture2D						g_bindless_srvs[]				   : register(t0, space3);
 StructuredBuffer<RT_Triangle>	g_bindless_triangle_buffers[]	   : register(t0, space4);
 

--- a/RT/Renderer/Backend/DX12/assets/shaders/include_shared/shared_common.hlsl.h
+++ b/RT/Renderer/Backend/DX12/assets/shaders/include_shared/shared_common.hlsl.h
@@ -95,6 +95,7 @@ struct GlobalConstantBuffer
 
 	// What segment/cube is viewer in
 	int ray_segment;
+	uint num_segments;  // total in level
 	bool external;
 };
 

--- a/RT/Renderer/Backend/DX12/assets/shaders/occlusion.hlsl
+++ b/RT/Renderer/Backend/DX12/assets/shaders/occlusion.hlsl
@@ -41,63 +41,24 @@ void TraceOcclusionRay(RayDesc ray, inout OcclusionRayPayload payload, uint2 pix
 
 				bool valid_hit = true;
 
-				if (tweak.retrace_rays && payload.start_segment != -1)  // retrace rays to handle intersecting level segments
+				
+
+				bool segment_visible = true;
+
+				if (hit_triangle.segment != -1)
 				{
-					// bool found = false;
+					uint visibility_table_stride = (g_global_cb.num_segments + 31) / 32;
+					uint wordIndex = hit_triangle.segment / 32;
+					uint bitIndex = hit_triangle.segment % 32;
+					uint table_index = payload.start_segment * visibility_table_stride + wordIndex;
 
-					 // first check if the hit triangle is part of the segment we are looking for
-					if (hit_triangle.segment != -1 && hit_triangle.segment != payload.start_segment)
-					{
-						// if not, setup a retrace ray that starts at the hit location and shoots back to the viewer
-						float3 newOrigin = ray.Origin + (ray.Direction * hit_distance);
-						RayDesc retrace_ray;
-						retrace_ray.Origin = newOrigin;
-						retrace_ray.Direction = ray.Direction * -1.0;
-						retrace_ray.TMin = 0.0;
-						retrace_ray.TMax = hit_distance + 1.0;	// add just a little bit to distance... it helps when the camera is close to a portal surface.
-
-						// setup retrace to check if it passes through portal that leads to segment hit happened in.
-						PortalRetraceRayPayload retrace_payload;
-						retrace_payload.search_segment = hit_triangle.segment;
-						retrace_payload.found = false;
-						retrace_payload.hit_distance = RT_RAY_T_MAX;
-						retrace_payload.next_segment = -1;
-
-						TracePortalRetraceRay(retrace_ray, retrace_payload, pixel_pos, false);
-
-						// retrace did pass through portal that leads to where the hit happened
-						if (retrace_payload.found)
-						{
-							// does that portal lead to where the player ship is?
-							if (retrace_payload.next_segment != payload.start_segment)
-							{
-								// if it does not, do one more retrace
-								retrace_payload.search_segment = retrace_payload.next_segment;
-								retrace_payload.found = false;
-								retrace_payload.hit_distance = RT_RAY_T_MAX;
-								retrace_payload.next_segment = -1;
-
-								TracePortalRetraceRay(retrace_ray, retrace_payload, pixel_pos, false);
-								if (!retrace_payload.found)
-								{
-									// failed second retrace, not valid hit
-									valid_hit = false;
-								}
-							}
-
-						}
-						else
-						{
-							valid_hit = false;
-						}
-					}
-
+					segment_visible = (g_visibility_table_buffer[table_index] & (1U << bitIndex)) != 0;
 				}
 
 				Material hit_material;
 
 				
-				if (valid_hit && !IsHitTransparent(
+				if (valid_hit && segment_visible && !IsHitTransparent(
 					ray_query.CandidateInstanceIndex(),
 					ray_query.CandidatePrimitiveIndex(),
 					ray_query.CandidateTriangleBarycentrics(),

--- a/RT/Renderer/Backend/DX12/assets/shaders/primary_ray.hlsli
+++ b/RT/Renderer/Backend/DX12/assets/shaders/primary_ray.hlsli
@@ -117,13 +117,10 @@ void TracePrimaryRay(RayDesc ray, inout PrimaryRayPayload payload, uint2 pixel_p
                     uint visibility_table_stride = (g_global_cb.num_segments + 31) / 32;
                     uint wordIndex = hit_triangle.segment / 32;
                     uint bitIndex = hit_triangle.segment % 32;
-                    uint table_index = g_global_cb.ray_segment * visibility_table_stride + wordIndex;
+                    uint table_index = payload.start_segment * visibility_table_stride + wordIndex;
 
-                    //segment_visible = (g_visibility_table_buffer[table_index] & (1U << bitIndex)) != 0;
-                    segment_visible = g_visibility_table_buffer[0] != 0; // temp test to see if any data is present in first index. so far this is always 0, despite on cpu array there being data. 
+                    segment_visible = (g_visibility_table_buffer[table_index] & (1U << bitIndex)) != 0;
                 }
-
-                //segment_visible = g_global_cb.num_segments < 300;
 
 				// Check for transparency on hit candidate
                

--- a/RT/Renderer/Backend/DX12/assets/shaders/primary_ray.hlsli
+++ b/RT/Renderer/Backend/DX12/assets/shaders/primary_ray.hlsli
@@ -38,7 +38,7 @@ void TracePrimaryRay(RayDesc ray, inout PrimaryRayPayload payload, uint2 pixel_p
 		switch (ray_query.CandidateType())
 		{
 			case CANDIDATE_NON_OPAQUE_TRIANGLE:
-			{
+            {
                 uint instance_idx = ray_query.CandidateInstanceIndex();
                 uint primitive_idx = ray_query.CandidatePrimitiveIndex();
 
@@ -46,11 +46,11 @@ void TracePrimaryRay(RayDesc ray, inout PrimaryRayPayload payload, uint2 pixel_p
                 RT_Triangle hit_triangle = GetHitTriangle(instance_data.triangle_buffer_idx, primitive_idx);
                 float hit_distance = ray_query.CandidateTriangleRayT();
 
-				Material hit_material;
+                Material hit_material;
 
                 bool valid_hit = true;
 
-                if (tweak.retrace_rays && payload.start_segment != -1)  // retrace rays to handle intersecting level segments
+                /*if (tweak.retrace_rays && payload.start_segment != -1)  // retrace rays to handle intersecting level segments
                 {
                    // bool found = false;
 
@@ -93,7 +93,7 @@ void TracePrimaryRay(RayDesc ray, inout PrimaryRayPayload payload, uint2 pixel_p
                                     valid_hit = false;
                                 }
                             }
-                           
+
                         }
                         else
                         {
@@ -101,11 +101,33 @@ void TracePrimaryRay(RayDesc ray, inout PrimaryRayPayload payload, uint2 pixel_p
                         }
                     }
 
+                }*/
+
+                // check visibility table
+
+                //g_global_cb.ray_segment;
+                //g_global_cb.num_segments;
+                //g_visibility_table_buffer;
+                //hit_triangle.segment;
+
+                bool segment_visible = true;
+
+                if (hit_triangle.segment != -1)
+                {
+                    uint visibility_table_stride = (g_global_cb.num_segments + 31) / 32;
+                    uint wordIndex = hit_triangle.segment / 32;
+                    uint bitIndex = hit_triangle.segment % 32;
+                    uint table_index = g_global_cb.ray_segment * visibility_table_stride + wordIndex;
+
+                    //segment_visible = (g_visibility_table_buffer[table_index] & (1U << bitIndex)) != 0;
+                    segment_visible = g_visibility_table_buffer[0] != 0; // temp test to see if any data is present in first index. so far this is always 0, despite on cpu array there being data. 
                 }
+
+                //segment_visible = g_global_cb.num_segments < 300;
 
 				// Check for transparency on hit candidate
                
-                if (valid_hit && !IsHitTransparent(
+                if (valid_hit && segment_visible && !IsHitTransparent(
                     instance_idx,
                     primitive_idx,
                     ray_query.CandidateTriangleBarycentrics(),

--- a/RT/Renderer/Backend/DX12/src/GlobalDX.h
+++ b/RT/Renderer/Backend/DX12/src/GlobalDX.h
@@ -227,11 +227,11 @@ namespace RT
 		D3D12GlobalDescriptors_SRV_InstanceDataBuffer,
 		D3D12GlobalDescriptors_SRV_MaterialEdges,
 		D3D12GlobalDescriptors_SRV_MaterialIndices,
+		D3D12GlobalDescriptors_SRV_VisibilityTableBuffer,
 		D3D12GlobalDescriptors_SRV_BlueNoiseFirst,
 		D3D12GlobalDescriptors_SRV_BlueNoiseLast = D3D12GlobalDescriptors_SRV_BlueNoiseFirst + BLUE_NOISE_TEX_COUNT - 1,
 		D3D12GlobalDescriptors_SRV_ImGui,
-		D3D12GlobalDescriptors_SRV_VisibilityTableBuffer,
-
+	
 		D3D12GlobalDescriptors_CBV_GlobalConstantBuffer,
 		D3D12GlobalDescriptors_CBV_TweakVars,
 		
@@ -471,6 +471,7 @@ namespace RT
 		int upscaling_aa_mode;
 		int amd_fsr2_mode;
 
+		uint32_t visibility_table_element_count;
 		uint32_t visibility_table_segment_count;
 		ID3D12Resource* visibility_table_buffer;
 	};

--- a/RT/Renderer/Backend/DX12/src/GlobalDX.h
+++ b/RT/Renderer/Backend/DX12/src/GlobalDX.h
@@ -230,9 +230,11 @@ namespace RT
 		D3D12GlobalDescriptors_SRV_BlueNoiseFirst,
 		D3D12GlobalDescriptors_SRV_BlueNoiseLast = D3D12GlobalDescriptors_SRV_BlueNoiseFirst + BLUE_NOISE_TEX_COUNT - 1,
 		D3D12GlobalDescriptors_SRV_ImGui,
+		D3D12GlobalDescriptors_SRV_VisibilityTableBuffer,
 
 		D3D12GlobalDescriptors_CBV_GlobalConstantBuffer,
 		D3D12GlobalDescriptors_CBV_TweakVars,
+		
 
 		// ------------------------------------------------------------------
 		// Render targets
@@ -468,6 +470,9 @@ namespace RT
 
 		int upscaling_aa_mode;
 		int amd_fsr2_mode;
+
+		uint32_t visibility_table_segment_count;
+		ID3D12Resource* visibility_table_buffer;
 	};
 
 	extern D3D12State g_d3d;

--- a/RT/Renderer/Backend/DX12/src/RenderBackend.cpp
+++ b/RT/Renderer/Backend/DX12/src/RenderBackend.cpp
@@ -2102,6 +2102,39 @@ namespace
 		result->triangle_buffer_descriptor = descriptor;
 	}
 
+	struct CreateVisibilityBuffersResult
+	{
+		ID3D12Resource* visibility_table_buffer;
+		DescriptorAllocation visibility_table_buffer_descriptor;
+	};
+
+	void CreateVisibilityTableBuffers(size_t visibility_table_element_count, uint32_t* visibility_table, CreateVisibilityBuffersResult* result)
+	{
+		RT_ZERO_STRUCT(result);
+
+		size_t visibility_table_buffer_size = sizeof(uint32_t) * visibility_table_element_count;
+		//ID3D12Resource* visibility_table_buffer = RT_CreateReadOnlyBuffer(L"Visibility Table Buffer", visibility_table_buffer_size);
+		g_d3d.visibility_table_buffer = RT_CreateReadOnlyBuffer(L"Visibility Table Buffer", visibility_table_buffer_size);
+
+		RingBufferAllocation ring_buf_alloc = WriteToRingBuffer(&g_d3d.resource_upload_ring_buffer, visibility_table_buffer_size, alignof(uint32_t), visibility_table);
+		CommandList& command_list = *ring_buf_alloc.command_list;
+		CopyBufferRegion(command_list, g_d3d.visibility_table_buffer, 0, ring_buf_alloc.resource, ring_buf_alloc.byte_offset, visibility_table_buffer_size);
+
+		DescriptorAllocation descriptor = g_d3d.cbv_srv_uav.Allocate(25);
+		auto visibility_table_srv = descriptor.GetCPUDescriptor(D3D12GlobalDescriptors_SRV_VisibilityTableBuffer);
+		CreateBufferSRV(g_d3d.visibility_table_buffer, visibility_table_srv, 0, (uint32_t)visibility_table_element_count, sizeof(uint32_t));
+
+		ResourceTransition(command_list, g_d3d.visibility_table_buffer, D3D12_RESOURCE_STATE_GENERIC_READ);
+		//g_d3d.command_queue_direct->ExecuteCommandList(command_list);
+
+		//UAVBarrier(command_list, bottom_level_as);
+		//RT_TRACK_TEMP_RESOURCE(g_d3d.visibility_table_buffer, &command_list);
+
+		// do I need these for anything... not currently doing anything with them in the calling function.
+		result->visibility_table_buffer = g_d3d.visibility_table_buffer;
+		result->visibility_table_buffer_descriptor = descriptor;
+	}
+
 	ID3D12Resource* BuildBLAS(size_t triangle_count, RT_Triangle *triangles, D3D12_RAYTRACING_GEOMETRY_FLAGS flags)
 	{
 		size_t vertices_size = triangle_count*3*sizeof(RT_Vec3);
@@ -2292,6 +2325,7 @@ namespace
 			frame->lights = AllocateFromUploadBuffer(frame, sizeof(RT_Light) * RT_MAX_LIGHTS);
 			frame->material_edges = AllocateFromUploadBuffer(frame, sizeof(RT_MaterialEdge) * RT_MAX_MATERIAL_EDGES);
 			frame->material_indices = AllocateFromUploadBuffer(frame, sizeof(uint16_t) * RT_MAX_MATERIALS);
+			frame->visibility_table = AllocateFromUploadBuffer(frame, sizeof(uint32_t) * 282 * RT_MAX_SEGMENTS);  // 282 is the number of uint32_t's to store 9000 segments bit packed.
 
 			frame->upload_buffer_arena_reset = RT_ArenaGetMarker(&frame->upload_buffer_arena);
 		}
@@ -3171,6 +3205,7 @@ void RenderBackend::EndScene()
 			scene_cb->screen_color_overlay = g_d3d.io.screen_overlay_color;
 
 			scene_cb->ray_segment = g_d3d.scene.render_segment;
+			scene_cb->num_segments = g_d3d.visibility_table_segment_count;
 			scene_cb->external = g_d3d.scene.external;
 			
 			D3D12_CPU_DESCRIPTOR_HANDLE cbv = frame->descriptors.GetCPUDescriptor(D3D12GlobalDescriptors_CBV_GlobalConstantBuffer);
@@ -3545,6 +3580,17 @@ RT_ResourceHandle RenderBackend::UploadMesh(const RT_UploadMeshParams& mesh_para
 	resource.triangle_buffer_descriptor = result.triangle_buffer_descriptor;
 
 	return g_mesh_slotmap.Insert(resource);
+}
+
+void RenderBackend::UploadVisibilityTable(const RT_UploadVisibilityTableParams& visibility_params)
+{
+	//does this need a resource handle?
+
+	CreateVisibilityBuffersResult result;
+	CreateVisibilityTableBuffers(visibility_params.visibility_table_element_count, visibility_params.visibility_table, &result);
+
+	g_d3d.visibility_table_segment_count = visibility_params.visibility_table_segment_count;
+	//g_d3d.visibility_table_buffer = result.visibility_table_buffer;
 }
 
 void RenderBackend::ReleaseTexture(const RT_ResourceHandle texture_handle)

--- a/RT/Renderer/Backend/DX12/src/RenderBackend.cpp
+++ b/RT/Renderer/Backend/DX12/src/RenderBackend.cpp
@@ -2325,8 +2325,7 @@ namespace
 			frame->lights = AllocateFromUploadBuffer(frame, sizeof(RT_Light) * RT_MAX_LIGHTS);
 			frame->material_edges = AllocateFromUploadBuffer(frame, sizeof(RT_MaterialEdge) * RT_MAX_MATERIAL_EDGES);
 			frame->material_indices = AllocateFromUploadBuffer(frame, sizeof(uint16_t) * RT_MAX_MATERIALS);
-			frame->visibility_table = AllocateFromUploadBuffer(frame, sizeof(uint32_t) * 282 * RT_MAX_SEGMENTS);  // 282 is the number of uint32_t's to store 9000 segments bit packed.
-
+			
 			frame->upload_buffer_arena_reset = RT_ArenaGetMarker(&frame->upload_buffer_arena);
 		}
 	}
@@ -3584,13 +3583,26 @@ RT_ResourceHandle RenderBackend::UploadMesh(const RT_UploadMeshParams& mesh_para
 
 void RenderBackend::UploadVisibilityTable(const RT_UploadVisibilityTableParams& visibility_params)
 {
-	//does this need a resource handle?
+	if (g_d3d.visibility_table_buffer)
+	{
+		// NOTE(daniel): Copying Justin's dirty hack below, defer releasing the old table until we know for sure it's no longer used.
+		CommandList * cmd_list = &g_d3d.command_queue_direct->GetCommandList();
+		RT_TRACK_TEMP_OBJECT(g_d3d.visibility_table_buffer, cmd_list);
+	}
 
-	CreateVisibilityBuffersResult result;
-	CreateVisibilityTableBuffers(visibility_params.visibility_table_element_count, visibility_params.visibility_table, &result);
+	size_t visibility_table_buffer_size = sizeof(uint32_t) * visibility_params.visibility_table_element_count;
+	ID3D12Resource * visibility_table_buffer = RT_CreateReadOnlyBuffer(L"Visibility Table Buffer", visibility_table_buffer_size);
 
+	RingBufferAllocation ring_buf_alloc = WriteToRingBuffer(&g_d3d.resource_upload_ring_buffer, visibility_table_buffer_size, alignof(uint32_t), visibility_params.visibility_table);
+	CommandList & command_list = *ring_buf_alloc.command_list;
+	CopyBufferRegion(command_list, visibility_table_buffer, 0, ring_buf_alloc.resource, ring_buf_alloc.byte_offset, visibility_table_buffer_size);
+	
+	ResourceTransition(command_list, visibility_table_buffer, D3D12_RESOURCE_STATE_GENERIC_READ);
+	
+	g_d3d.visibility_table_buffer = visibility_table_buffer;
+	g_d3d.visibility_table_element_count = visibility_params.visibility_table_element_count;
 	g_d3d.visibility_table_segment_count = visibility_params.visibility_table_segment_count;
-	//g_d3d.visibility_table_buffer = result.visibility_table_buffer;
+
 }
 
 void RenderBackend::ReleaseTexture(const RT_ResourceHandle texture_handle)
@@ -4107,6 +4119,14 @@ void RenderBackend::RaytraceRender()
 
 		D3D12_CPU_DESCRIPTOR_HANDLE srv = frame->descriptors.GetCPUDescriptor(D3D12GlobalDescriptors_SRV_InstanceDataBuffer);
 		CreateBufferSRV(g_d3d.instance_data_buffer, srv, 0, MAX_INSTANCES, sizeof(InstanceData));
+	}
+
+	//------------------------------------------------------------------------
+	// Create SRV for visibility table
+	
+	{
+		D3D12_CPU_DESCRIPTOR_HANDLE srv = frame->descriptors.GetCPUDescriptor(D3D12GlobalDescriptors_SRV_VisibilityTableBuffer);
+		CreateBufferSRV(g_d3d.visibility_table_buffer, srv, 0, (uint32_t)g_d3d.visibility_table_element_count, sizeof(uint32_t));
 	}
 
 	// ------------------------------------------------------------------

--- a/RT/Renderer/Backend/DX12/src/RenderBackend.h
+++ b/RT/Renderer/Backend/DX12/src/RenderBackend.h
@@ -26,6 +26,7 @@ namespace RenderBackend
 
 	RT_ResourceHandle UploadTexture(const RT_UploadTextureParams& texture_params);
 	RT_ResourceHandle UploadMesh(const RT_UploadMeshParams& mesh_params);
+	void UploadVisibilityTable(const RT_UploadVisibilityTableParams& visibility_params);
 	void ReleaseTexture(const RT_ResourceHandle texture_handle);
 	void ReleaseMesh(const RT_ResourceHandle mesh_handle);
 	uint16_t UpdateMaterial(uint16_t material_index, const RT_Material *material);

--- a/RT/Renderer/Backend/DX12/src/Renderer.cpp
+++ b/RT/Renderer/Backend/DX12/src/Renderer.cpp
@@ -185,6 +185,11 @@ RT_ResourceHandle RT_UploadMesh(const RT_UploadMeshParams* params)
 	return RenderBackend::UploadMesh(*params);
 }
 
+void RT_UploadVisibilityTable(const RT_UploadVisibilityTableParams* params)
+{
+	RenderBackend::UploadVisibilityTable(*params);
+}
+
 void RT_ReleaseTexture(const RT_ResourceHandle texture_handle)
 {
 	RenderBackend::ReleaseTexture(texture_handle);

--- a/d1/include/vecmat.h
+++ b/d1/include/vecmat.h
@@ -452,4 +452,6 @@ void vms_matrix_from_quaternion(vms_matrix * m, const vms_quaternion * q);
 bool vm_vec_equal(const vms_vector * v1, const vms_vector * v2);
 bool vm_mat_equal(const vms_matrix * m1, const vms_matrix * m2);
 
+extern void make_random_vector(vms_vector* vec);
+
 #endif // #ifndef _VECMAT_H

--- a/d1/main/ai.c
+++ b/d1/main/ai.c
@@ -1171,6 +1171,7 @@ void ai_move_relative_to_player(object *objp, ai_local *ailp, fix dist_to_player
 
 }
 
+/*
 // --------------------------------------------------------------------------------------------------------------------
 //	Compute a somewhat random, normalized vector.
 void make_random_vector(vms_vector *vec)
@@ -1181,6 +1182,7 @@ void make_random_vector(vms_vector *vec)
 
 	vm_vec_normalize_quick(vec);
 }
+*/
 
 //	-------------------------------------------------------------------------------------------------------------------
 int	Break_on_object = -1;

--- a/d1/main/ai.h
+++ b/d1/main/ai.h
@@ -66,7 +66,7 @@ extern void init_ai_objects(void);
 extern void do_ai_robot_hit(object *robot, int type);
 extern void create_n_segment_path(object *objp, int path_length, int avoid_seg);
 extern void create_n_segment_path_to_door(object *objp, int path_length, int avoid_seg);
-extern void make_random_vector(vms_vector *vec);
+//extern void make_random_vector(vms_vector *vec);
 extern void init_robots_for_level(void);
 extern int ai_behavior_to_mode(int behavior);
 

--- a/d1/main/fvi.c
+++ b/d1/main/fvi.c
@@ -924,7 +924,8 @@ static int fvi_sub(vms_vector *intp,int *ints,const vms_vector *p0,int startseg,
 							wid_flag = WALL_IS_DOORWAY(seg, side);
 						}
 
-						if ((wid_flag & WID_FLY_FLAG) ||
+						if ( ((flags & FQ_ALL_CHILDREN ) && seg->children[side] >= 0) || 
+							(wid_flag & WID_FLY_FLAG) ||
 							((wid_flag == WID_TRANSPARENT_WALL) && 
 								((flags & FQ_TRANSWALL) || (flags & FQ_TRANSPOINT && check_trans_wall(&hit_point,seg,side,face))))) {
 

--- a/d1/main/fvi.h
+++ b/d1/main/fvi.h
@@ -106,6 +106,7 @@ typedef struct fvi_info {
 #define FQ_TRANSWALL		2		//go through transparent walls
 #define FQ_TRANSPOINT	4		//go through trans wall if hit point is transparent
 #define FQ_GET_SEGLIST	8		//build a list of segments
+#define FQ_ALL_CHILDREN 16		// traverse all children (ignoring if there is wall or door in way)
 
 //this data contains the parms to fvi()
 typedef struct fvi_query {

--- a/d1/maths/vecmat.c
+++ b/d1/maths/vecmat.c
@@ -906,3 +906,15 @@ bool vm_vec_equal(const vms_vector * v1, const vms_vector * v2) {
 bool vm_mat_equal(const vms_matrix * m1, const vms_matrix * m2) {
 	return vm_vec_equal(&m1->rvec, &m2->rvec) && vm_vec_equal(&m1->uvec, &m2->uvec) && vm_vec_equal(&m1->fvec, &m2->fvec);
 }
+
+
+// --------------------------------------------------------------------------------------------------------------------
+//	Compute a somewhat random, normalized vector.
+void make_random_vector(vms_vector *vec)
+{
+		vec->x = (d_rand() - 16384) | 1;  // make sure we don't create null vector
+		vec->y = d_rand() - 16384;
+		vec->z = d_rand() - 16384;
+
+	vm_vec_normalize_quick(vec);
+}


### PR DESCRIPTION
- moved existing make_random_vector from ai.c/h to vecmat.c/h
- level.c: included fvi.h to use find_vector_intersection function
- level.c: updated RT_UploadLevelGeometry to add visibility table creation and upload
- GlobalDX.h: added D3D12GlobalDescriptors_SRV_VisibilityTableBuffer to D3D12GlobalDescriptors
- Renderer.cpp: added function RT_UploadVisibilityTable to upload visibility table to GPU
- RenderBackend.cpp: added function CreateVisibilityTableBuffers (based on CreateMeshBuffers) to create visibility table buffer and copy visibility table data into it 
- common.hlsl: added new SRV g_visibility_table_buffer StructuredBuffer
- shared_common.hlsl.h: added new member num_segments to GlobalConstantBuffer to be able to calculate visibility table offsets in hlsl code
- primary_ray.hlsli: updated TracePrimaryRay to remove retrace_rays test and use visibility table instead.